### PR TITLE
irqbalance: Call parse_proc_stat after CPU tree rebuild during CPU ho…

### DIFF
--- a/irqbalance.c
+++ b/irqbalance.c
@@ -270,7 +270,6 @@ gboolean scan(gpointer data)
 	log(TO_CONSOLE, LOG_INFO, "\n\n\n-----------------------------------------------------------------------------\n");
 	clear_work_stats();
 	parse_proc_interrupts();
-	parse_proc_stat();
 
 
 	/* cope with cpu hotplug -- detected during /proc/interrupts parsing */
@@ -289,7 +288,8 @@ gboolean scan(gpointer data)
 		clear_work_stats();
 		parse_proc_interrupts();
 		parse_proc_stat();
-	} 
+	} else
+		parse_proc_stat();
 
 	if (cycle_count)	
 		update_migration_status();


### PR DESCRIPTION
…tplug detection

Whenever SMT level is changed on powerpc, the following warning is
logged in /var/log/messages which can add confusion to users.

WARNING, didn't collect load info for all cpus, balancing is broken

So execute parse_proc_stat() after clear/rebuild CPU tree during CPU
hotplug detection.

Signed-off-by: Haren Myneni <haren@us.ibm.com>